### PR TITLE
Feat/removed class tags-section-title from html and css

### DIFF
--- a/meta/static/css/tags_page.css
+++ b/meta/static/css/tags_page.css
@@ -3,11 +3,6 @@
 
   *Each Category is a card
 */
-
-.tags-section-title {
-  width: fit-content;
-  font-size: 1.5em;
-}
   
 .tags-content {
   display: flex;

--- a/meta/templates/tags_page.html
+++ b/meta/templates/tags_page.html
@@ -19,7 +19,7 @@ Página mostra os marcadores agrupados por categoria em quatro colunas. Usa o re
 <meta property="og:type" content="article" />
 {% endblock %}
 {% block content %}
-<header class="tags-section-title"><h1>{% trans 'Marcadores' %}</h1></header>
+<header><h1>{% trans 'Marcadores' %}</h1></header>
 <section class="tags-content">
     <div class="tags-categories">
         {% for cat in cats %}


### PR DESCRIPTION
I removed class "tags-section-title" from the title's html on tags_page.html and the css on tags_page.css, in order to make the title the same size as the others.