### PR TITLE
style review in the Photo menu and video menu when browsing pagination

### DIFF
--- a/meta/templates/nav.html
+++ b/meta/templates/nav.html
@@ -19,8 +19,8 @@
   </ul>
 
   <ul class="menu" id="media">
-    <li> <a {% if fullpath == '/search/?datatype=photo' %}class="selected"{% endif %} href="/search/?datatype=photo">{% trans 'fotos' %}</a> </li>
-    <li> <a {% if fullpath == '/search/?datatype=video' %}class="selected"{% endif %} href="/search/?datatype=video">{% trans 'vídeos' %}</a> </li>
+    <li> <a {% if request.GET.datatype == 'photo' %}class="selected"{% endif %} href="/search/?datatype=photo">{% trans 'fotos' %}</a> </li>
+    <li> <a {% if request.GET.datatype == 'video' %}class="selected"{% endif %} href="/search/?datatype=video">{% trans 'vídeos' %}</a> </li>
     <li> <a {% if fullpath == '/tours/' %}class="selected"{% endif %} href="{% url 'tours_url' %}">{% trans 'tours' %}</a> </li>
     <li> <a {% if fullpath == '/taxa/' %}class="selected"{% endif %} href="{% url 'taxa_url' %}">{% trans 'táxons' %}</a> </li>
     <li> <a {% if fullpath == '/tags/' %}class="selected"{% endif %} href="{% url 'tags_url' %}">{% trans 'marcadores' %}</a> </li>


### PR DESCRIPTION
When the user clicks on Photos or Videos, and browses the media pagination, the "selected" class is removed from the menu.

Correction: check if the datatype==video or datatype==photo parameter exists in the url