### PR TITLE
added distinct() to the function's Media.objects

### DIFF
--- a/meta/templatetags/extra_tags.py
+++ b/meta/templatetags/extra_tags.py
@@ -128,7 +128,7 @@ def slicer(query, media_id):
 def get_media_queryset(media, qobj):
     '''Returns queryset used in the linear browser.'''
     Media = apps.get_model('meta', 'Media')
-    query = Media.objects.filter(qobj, is_public=True).order_by('id')
+    query = Media.objects.filter(qobj, is_public=True).order_by('id').distinct()
     return query
 
 @register.inclusion_tag('related.html', takes_context=True)


### PR DESCRIPTION
When the media has two taxons, the "related" component displays the duplicate image.

Correction: added distinct() to the function's Media.objects